### PR TITLE
Make codespell a mandatory test

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,4 +6,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: pip install codespell
-      - run: codespell --ignore-words=codespell.txt || exit 1  # --ignore-words-list="" --skip="*.css,*.js,*.lock,*.po"
+      - run: codespell --ignore-words=codespell.txt


### PR DESCRIPTION
Typos will cause the GitHub Action to fail.